### PR TITLE
Marks ButtplugLite as cross platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ know!](https://github.com/buttplugio/awesome-buttplug/issues)
 
 - [ButtplugLite](https://github.com/runtime-shady-backroom/buttplug-lite)
   - Free, open source, repo at https://github.com/runtime-shady-backroom/buttplug-lite
-  - Windows executables in release, may be cross-platform compatible?
+  - Desktop Cross Platform
   - Scaled back version of the Buttplug Protocol for use with [NeosVR LogiX](https://neosvr.com)
 - [Second Life Interface to ToyWebBridge](https://github.com/kyrahabattoir/ToyWebBridge/tree/master/Examples/LSL%20(Second%20Life))
   - Free, open source, repo at https://github.com/kyrahabattoir/ToyWebBridge


### PR DESCRIPTION
I've finally gotten off my ass and set up GitHub actions to build Windows, Linux, and macOS artifacts for my [releases](https://github.com/runtime-shady-backroom/buttplug-lite/releases). I *think* that "Desktop Cross Platform" is the correct thing to write here, going off of the other programs in the list?

Also, the [buttplug compiling documentation](https://github.com/buttplugio/buttplug/tree/2bc8bdab9743c72b530895237f82d8fecaa732a7/buttplug#compiling) doesn't mention it but `libdbus-1-dev` is needed on the Linux build machine. ...Although, that could just be because I'm using non-default buttplug features.