### PR TITLE
Update Risk of Rain 2 mods

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ know!](https://github.com/buttplugio/awesome-buttplug/issues)
   * [Audio Sync](#audio-sync)
 * [Games](#games)
 * [Game Mods](#game-mods)
+  * [Risk of Rain 2](#risk-of-rain-2)
   * [Minecraft](#minecraft)
   * [FFXIV](#ffxiv)
 * [Virtual Worlds (General)](#virtual-worlds)
@@ -90,7 +91,7 @@ know!](https://github.com/buttplugio/awesome-buttplug/issues)
   - Cross platform (web)
   - WebRTC P2P based toy sharing and controller application that's installable as a PWA for offline use.
 - [Beadi](https://thatbatluna.github.io/Beadi/)
-  - Free, open source, repo at https://github.com/ThatBatLuna/Beadi  
+  - Free, open source, repo at https://github.com/ThatBatLuna/Beadi
   - Web based (Cross platform, either via browsers or Intiface Central)
   - Visual node-based editor for programming Buttplug-compatible toys
 - [Ahegao Detector](https://ahegao-detector.netlify.app/)
@@ -178,7 +179,7 @@ know!](https://github.com/buttplugio/awesome-buttplug/issues)
   - Paid, available on [Steam](https://store.steampowered.com/app/1571340/)
   - Windows 10+ only, VR only
   - Integrates [Buttplug Unity](https://github.com/buttplugio/buttplug-unity) for toy control within
-    interactive scenes.    
+    interactive scenes.
 - [Caveman BIOS Teaches Erotic Typing](https://curiousjp.itch.io/caveman-bios-teaches-erotic-typing)
   - Free, available on [itch.io](https://curiousjp.itch.io/caveman-bios-teaches-erotic-typing)
   - Cross-platform (pygame)
@@ -239,7 +240,7 @@ know!](https://github.com/buttplugio/awesome-buttplug/issues)
 - [SDTButtplug](https://github.com/Nootna8/SDTButtplug)
   - Free, open source, repo at https://github.com/Nootna8/SDTButtplug
   - Windows 10+ only (requires [Intiface Central](https://intiface.com/central))
-  - SuperDeepthroat sex toy integration  
+  - SuperDeepthroat sex toy integration
 - [COM3D2.ToySynchronizer.Plugin](https://github.com/amateras977/COM3D2.ToySynchronizer.Plugin)
   - Free, proprietary, available at https://github.com/amateras977/COM3D2.ToySynchronizer.Plugin
   - Windows 10+ only
@@ -272,12 +273,6 @@ know!](https://github.com/buttplugio/awesome-buttplug/issues)
   - Free, closed source (RPGMaker mod)
   - Windows 10+ only
   - Buttplug integration for [Lust Doll+](https://indivi.itch.io/ldplus)
-- [Risk of Rumble](https://github.com/mistername/RiskOfRainModding/tree/master/RiskOfRumble)
-  - Free, open source, repo at
-    https://github.com/mistername/RiskOfRainModding/tree/master/RiskOfRumble ([Thunderstore
-    Link](https://thunderstore.io/package/MisterKinky/RiskOfRumble/))
-  - Windows 10+ only
-  - Buttplug integration for Risk of Rain 2
 - [Game Interface For Toys (Skyrim and Fallout 4)](https://github.com/MinLL/GameInterfaceForToys)
   - Free, open source, repo at https://github.com/MinLL/GameInterfaceForToys
   - Windows 10+ only
@@ -287,8 +282,19 @@ know!](https://github.com/buttplugio/awesome-buttplug/issues)
   - Cross Platform (requires [Intiface Central](https://intiface.com/central))
   - Buttplug integration for Terraria
 
+### Risk of Rain 2
+
+- [Updated RiskOfRumble](https://thunderstore.io/package/exp111/RiskOfRumble)
+  - Free, open source, repo at https://github.com/exp111/RoR2Stuff/tree/master/RiskOfRumble
+  - Windows 10+ only (requires [Intiface Central](https://intiface.com/central))
+  - Updated version of [RiskOfRumble](https://thunderstore.io/package/MisterKinky/RiskOfRumble)
+- [RumbleRain](https://thunderstore.io/package/quasikyo/RumbleRain)
+  - Free, open source, repo at https://github.com/quasikyo/rumble-rain
+  - Windows 10+ only (requires [Intiface Central](https://intiface.com/central))
+  - Configurable vibrations in response to in-game damage events
+
 ### Minecraft
-  
+
 - [ButtplugMC (Minecraft)](https://github.com/Cyloci/ButtplugMc)
   - Free, open source, repo at https://github.com/Cyloci/ButtplugMc
   - Cross Platform (requires [Intiface Central](https://intiface.com/central))
@@ -303,7 +309,7 @@ know!](https://github.com/buttplugio/awesome-buttplug/issues)
   - Free, open source
   - Cross Platform (requires [Intiface Central](https://intiface.com/central))
 
-### FFXIV  
+### FFXIV
 
 - [FFXIV Vibe Plugin](https://github.com/kaciexx/FFXIV_Vibe_Plugin)
   - Free, open source, repo at https://github.com/kaciexx/FFXIV_Vibe_Plugin
@@ -397,7 +403,7 @@ know!](https://github.com/buttplugio/awesome-buttplug/issues)
   - Available via the github repo, not yet on Nuget
   - Maintained by Community Developers
   - C# Client written in pure .Net C#
-  
+
 #### JS/Typescript
 - [Buttplug JS/TS Client](https://github.com/buttplugio/buttplug-js)
   - Available on [NPM](https://www.npmjs.com/package/buttplug)
@@ -428,13 +434,13 @@ know!](https://github.com/buttplugio/awesome-buttplug/issues)
     Central](https://intiface.com/central) or [Intiface
     Engine](https://github.com/intiface/intiface-engine)
 
-#### Lua    
+#### Lua
 - [Buttplug Lua](https://github.com/abbihors/buttplug-lua)
   - Maintained by Community Developers
   - Standalone Lua client library for connecting to [Intiface
     Central](https://intiface.com/central) or [Intiface
     Engine](https://github.com/intiface/intiface-engine)
-  
+
 #### LISP
 - [Buttplug Common LISP](https://codeberg.org/poodlezone/cl-buttplug)
   - Maintained by Community Developers
@@ -458,7 +464,7 @@ know!](https://github.com/buttplugio/awesome-buttplug/issues)
   - [Sugarcube 2](https://www.motoslave.net/sugarcube/2/) macros for the [Twine Interactive Fiction
     Game Engine](https://twinery.org)
 - [Plug₂in for RPG Maker MV](https://qazm.itch.io/plug-in-for-rpg-maker-mv)
-  - RPGMaker support for Buttplug 
+  - RPGMaker support for Buttplug
 - [GSpot](https://github.com/deadpixelsociety/gspot)
   - Godot 4 Plugin for Buttplug
 - [Godot.Buttplug](https://github.com/nhydock/Godot.Buttplug)
@@ -486,7 +492,7 @@ know!](https://github.com/buttplugio/awesome-buttplug/issues)
   - Free, open source, repo at https://github.com/Furimanejo/In-Heat
   - Uses computer vision to track Heat Bar in Overwatch and control sex toys based on levels.
   - Deprecation Reason: Overwatch servers shut down in late 2022
-- [Healing Is Fun Overwatch Plugin](https://github.com/Sir-Prise/healsluts) 
+- [Healing Is Fun Overwatch Plugin](https://github.com/Sir-Prise/healsluts)
   - Free, open source, repo at https://github.com/Sir-Prise/healsluts
   - Web based system for Overwatch interaction
   - Deprecation Reason: Overwatch servers shut down in late 2022
@@ -507,18 +513,18 @@ know!](https://github.com/buttplugio/awesome-buttplug/issues)
 - [Plug Parser (FFXIV)](https://github.com/cyan-f/Plug_Parser)
   - Free, open source, repo at https://github.com/cyan-f/Plug_Parser
   - Windows 10+ only (requires [Intiface Central](https://intiface.com/central))
-  - FFXIV triggers for sex toy control, via [ACT](https://advancedcombattracker.com/)  
+  - FFXIV triggers for sex toy control, via [ACT](https://advancedcombattracker.com/)
   - Deprecation Reason: Dev moved on
 - [ButtPlACT (FFXIV)](https://github.com/crnlskn/ButtplACT)
   - Free, open source, repo at https://github.com/crnlskn/ButtplACT
   - Windows 10+ only (requires [Intiface Central](https://intiface.com/central))
   - FFXIV triggers for sex toy control, via [ACT](https://advancedcombattracker.com/)
-  - Deprecation Reason: Dev moved on  
+  - Deprecation Reason: Dev moved on
 - [Syncydink](https://syncydink.buttplug.world)
   - Free, open source, repo at https://github.com/qdot/syncydink
   - Web based (Cross platform via either browser or Intiface Central)
   - Web based movie playback system for funscript movies.
-  - Deprecation Reason: Dev moved on  
+  - Deprecation Reason: Dev moved on
 - [Buttplug Python](https://github.com/buttplugio/buttplug-py)
   - Available on [PyPi](https://pypi.org/project/buttplug/)
   - Written by Buttplug Core Team
@@ -526,6 +532,11 @@ know!](https://github.com/buttplugio/awesome-buttplug/issues)
     Central](https://intiface.com/central) or [Intiface
     Engine](https://github.com/intiface/intiface-engine)
   - Deprecation Reason: Core team ran out of time to support
+- [RiskOfRumble](https://thunderstore.io/package/MisterKinky/RiskOfRumble)
+  - Free, open source, repo at https://github.com/mistername/RiskOfRainModding/tree/master/RiskOfRumble
+  - Windows 10+ only
+  - Buttplug integration for Risk of Rain 2
+  - Deprecation Reason: Dev moved on
 
 ## Friends of Buttplug
 


### PR DESCRIPTION
Created a section for Risk of Rain 2 mods including [RumbleRain](https://thunderstore.io/package/quasikyo/RumbleRain) and the [updated Risk of Rumble](https://thunderstore.io/package/exp111/RiskOfRumble) that came from #50.

Resolves #50.
Resolves #55.